### PR TITLE
feat: support serialize by global_id of args.

### DIFF
--- a/sidekiq-cron.gemspec
+++ b/sidekiq-cron.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("fugit", "~> 1.8")
   s.add_dependency("sidekiq", ">= 4.2.1")
+  s.add_dependency("globalid", "= 1.0.0")
 
   s.add_development_dependency("minitest", "~> 5.15")
   s.add_development_dependency("mocha", "~> 1.14")


### PR DESCRIPTION
sidekiq-cronのJob引数をGlobalIDを使ったActiveRecordクラスのserialize/deserializeに対応させました。
https://railsguides.jp/active_job_basics.html#globalid

e.g. UserモデルをJobのパラメータとして使用する

```rb
class ExampleJob < ActiveJob::Base
  queue_as :default

  def perform(user)
    # Do something
  end
end
      
Sidekiq::Cron::Job.create(name: 'Example', cron: '*/5 * * * *', class: 'ExampleJob', args: User.first) 
Sidekiq::Cron::Job.create(name: 'Example', cron: '*/5 * * * *', class: 'ExampleJob', args: [User.first]) 
```

参考:
https://github.com/rails/rails/blob/v7.0.4/activejob/lib/active_job/arguments.rb